### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "bash"
+language = "ruby"
 run = ""

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ This repo is a collection of tools that have proven helpful for working with com
 
 Load the desired payload into a file `payload.rb` or `payload.json` depending on the tool, and then you can run each with `ruby main.rb` from within the tool directory.
 
-Tools were originally hosted on [repl.it](https://repl.it/@pawptart) and can be run there as well.
+Tools were originally hosted on [repl.it](https://repl.it/@pawptart) and can be run there as well. 
+
+[![Run on Repl.it](https://repl.it/badge/github/pawptart/json-tooling)](https://repl.it/github/pawptart/json-tooling)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@pawptart/json-tooling).